### PR TITLE
Moved the oslo.messaging entry to APIs.  Fixed stale URL in Rsyslog e…

### DIFF
--- a/data/apis.yaml
+++ b/data/apis.yaml
@@ -120,3 +120,11 @@ components:
     tags: [java]
     description: >-
       A thread-safe imperative Java messaging client
+  - name: OpenStack oslo.messaging
+    url: https://docs.openstack.org/oslo.messaging/latest
+    docs_url: https://docs.openstack.org/oslo.messaging/latest/admin/AMQP1.0.html
+    source_url: https://git.openstack.org/cgit/openstack/oslo.messaging/tree
+    package_url: https://pypi.org/project/oslo.messaging
+    tags: [openstack, python]
+    description: >-
+      Remote Procedure Call (RPC) and Notification library for Python clients

--- a/data/integrations.yaml
+++ b/data/integrations.yaml
@@ -31,20 +31,13 @@ components:
     tags: [serverless]
     description: >-
       An AMQP feed provider for OpenWhisk
-  - name: Oslo Messaging AMQP driver
-    url: https://docs.openstack.org/oslo.messaging/latest/admin/AMQP1.0.html
-    docs_url: https://github.com/openstack/oslo.messaging/blob/master/oslo_messaging/_drivers/amqp1_driver/oslo_messaging_amqp_driver_overview.rst
-    source_url: https://github.com/openstack/oslo.messaging/tree/master/oslo_messaging/_drivers/amqp1_driver
-    tags: [openstack]
-    description: >-
-      An AMQP driver for the OpenStack messaging API
   - name: Rsyslog AMQP output module
-    url: https://github.com/kgiusti/rsyslog-omamqp1/blob/master/README.md
-    docs_url: https://github.com/kgiusti/rsyslog-omamqp1/blob/master/external/python/README.md
-    source_url: https://github.com/kgiusti/rsyslog-omamqp1
+    url: https://www.rsyslog.com/
+    docs_url: https://github.com/rsyslog/rsyslog/tree/master/contrib/omamqp1
+    source_url: https://github.com/rsyslog/rsyslog/tree/master/contrib/omamqp1
     tags: [logging]
     description: >-
-      Rsyslog plugins for sending log messages to an AMQP message bus
+      Rsyslog plugin for sending log messages to an AMQP message bus
   - name: Spark Streaming AMQP connector
     url: https://github.com/radanalyticsio/streaming-amqp/blob/master/README.md
     maven_url: https://github.com/radanalyticsio/streaming-amqp#project-references


### PR DESCRIPTION
…ntry

The rsyslog plugin now resides in the official rsyslog sources - my old github repo is stale and needs to go away. The awkward bit is that both source and docs are the same link, but I'm ok with that.  Changed the homepage url to rsyslog since there's really no homepage for the plugin itself - not 100% happy with that so feel free to change.

I've taken the liberty to move the oslo.messaging stuff from integrations to APIs because, well, that's what oslo.messaging is: an RPC/Notification API that supports AMQP 1.0.   A project goal is not to tie oslo.messaging to openstack - it can be used stand alone.  Also updated urls and added pypi info.

Feedback appreciated